### PR TITLE
Bootstrap round tweaks

### DIFF
--- a/bootstrap.go
+++ b/bootstrap.go
@@ -115,7 +115,7 @@ func bootstrapRound(
 	connectedPeers := host.Network().Peers()
 
 	log.Debugf(
-		"%s bootstrap round start; currently connected to [%v] peers: %v\n",
+		"%s bootstrap round started; currently connected to [%v] peers: %v\n",
 		id,
 		len(connectedPeers),
 		connectedPeers,

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -146,7 +146,7 @@ func bootstrapRound(
 	if len(notConnected) < 1 {
 		log.Event(ctx, "bootstrapSkip", id)
 		log.Debugf(
-			"%s bootstrap round skipped; connected to all bootstrap nodes",
+			"%s bootstrap round skipped; connected to all bootstrap peers from config",
 			id,
 		)
 		return nil

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -111,6 +111,16 @@ func bootstrapRound(
 	defer cancel()
 
 	id := host.ID()
+
+	connectedPeers := host.Network().Peers()
+
+	log.Debugf(
+		"%s bootstrap round start; currently connected to [%v] peers: %v\n",
+		id,
+		len(connectedPeers),
+		connectedPeers,
+	)
+
 	// get bootstrap peers from config. retrieving them here makes
 	// sure we remain observant of changes to client configuration.
 	peers := cfg.BootstrapPeers()
@@ -118,7 +128,7 @@ func bootstrapRound(
 	if len(peers) == 0 {
 		log.Event(ctx, "bootstrapSkip", id)
 		log.Debugf(
-			"%s bootstrap round skipped -- no bootstrap peers in config",
+			"%s bootstrap round skipped; no bootstrap peers in config",
 			id,
 		)
 		return nil
@@ -136,7 +146,7 @@ func bootstrapRound(
 	if len(notConnected) < 1 {
 		log.Event(ctx, "bootstrapSkip", id)
 		log.Debugf(
-			"%s bootstrap round skipped -- connected to all bootstrap nodes",
+			"%s bootstrap round skipped; connected to all bootstrap nodes",
 			id,
 		)
 		return nil

--- a/bootstrap_test.go
+++ b/bootstrap_test.go
@@ -5,26 +5,8 @@ import (
 	"testing"
 
 	config "github.com/ipfs/go-ipfs-config"
-	pstore "github.com/libp2p/go-libp2p-peerstore"
-	testutil "github.com/libp2p/go-testutil"
+	"github.com/libp2p/go-testutil"
 )
-
-func TestSubsetWhenMaxIsGreaterThanLengthOfSlice(t *testing.T) {
-	var ps []pstore.PeerInfo
-	sizeofSlice := 100
-	for i := 0; i < sizeofSlice; i++ {
-		pid, err := testutil.RandPeerID()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		ps = append(ps, pstore.PeerInfo{ID: pid})
-	}
-	out := randomSubsetOfPeers(ps, 2*sizeofSlice)
-	if len(out) != len(ps) {
-		t.Fail()
-	}
-}
 
 func TestMultipleAddrsPerPeer(t *testing.T) {
 	var bsps []config.BootstrapPeer


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1639

So far, each bootstrap round started with a check of the `MinPeerThreshold`. If the number of connected peers exceeded this threshold, the bootstrap round was skipped. Such a situation may cause network topology breaks in case the client already received a big number of connections at their start (bigger than `MinPeerThreshold`)  because then the client opts out connection attempts to their bootstrap peers. 

In this pull request, we removed `MinPeerThreshold` check. Instead of it, the bootstrap round attempts to connect all not connected bootstrap peers.

